### PR TITLE
Fixes for Metric values, and test page.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/applicationinsights-mezzurite",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Logging Extention for Mezzurtie Timing Package",
   "main": "./browser/applicationInsight.mezzurite.umd.js",
   "module": "./dist-esm/index.js",

--- a/test/test.html
+++ b/test/test.html
@@ -11,9 +11,9 @@
         
         var mzLog = new ApplicationInsightsMezzurite.MezzuritePlugIn();
         var aiPath = "ai.1.min.js";
-
+        var ikey =  "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
         var sdkInstance="appInsightsSDK";window[sdkInstance]="appInsights";var aiName=window[sdkInstance],aisdk=window[aiName]||function(e){function n(e){t[e]=function(){var n=arguments;t.queue.push(function(){t[e].apply(t,n)})}}var t={config:e};t.initialize=!0;var i=document,a=window;setTimeout(function(){var n=i.createElement("script");n.src=e.url||aiPath,i.getElementsByTagName("script")[0].parentNode.appendChild(n)});try{t.cookie=i.cookie}catch(e){}t.queue=[],t.version=2;for(var r=["Event","PageView","Exception","Trace","DependencyData","Metric","PageViewPerformance"];r.length;)n("track"+r.pop());n("startTrackPage"),n("stopTrackPage");var o="Track"+r[0];if(n("start"+o),n("stop"+o),!(!0===e.disableExceptionTracking||e.extensionConfig&&e.extensionConfig.ApplicationInsightsAnalytics&&!0===e.extensionConfig.ApplicationInsightsAnalytics.disableExceptionTracking)){n("_"+(r="onerror"));var c=a[r];a[r]=function(e,n,i,a,o){var s=c&&c(e,n,i,a,o);return!0!==s&&t["_"+r]({message:e,url:n,lineNumber:i,columnNumber:a,error:o}),s},e.autoExceptionInstrumented=!0}return t}(
-            {instrumentationKey:"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", extensions: [mzLog]});if(window[aiName]=aisdk,aisdk.queue&&0===aisdk.queue.length){var pageViewItem={name:document.title?document.title:"",uri:document.URL?document.URL:""};aisdk.trackPageView(pageViewItem)}
+            {instrumentationKey:ikey, extensions: [mzLog]});if(window[aiName]=aisdk,aisdk.queue&&0===aisdk.queue.length){var pageViewItem={name:document.title?document.title:"",uri:document.URL?document.URL:""};aisdk.trackPageView(pageViewItem)}
 
         if(window[aiName]=aisdk,aisdk.queue&&0===aisdk.queue.length){var pageViewItem={name:document.title?document.title:"",uri:document.URL?document.URL:""};aisdk.trackPageView(pageViewItem)}
     </script>
@@ -29,12 +29,13 @@
           var t =document.getElementById("IncreaseBy"); 
           var increase = parseInt(t.value);
 
-          var routeNames = [{"name":'/', "minValue": 1000, "timetoSend":"8"},
-                            {"name":'/home', "minValue": 1500, "timetoSend":"2"},
-                            {"name":'/shop', "minValue": 3000, "timetoSend":"1"},
-                            {"name":'/shop/chart/', "minValue": 2000, "timetoSend":"3"},
-                            {"name":'/help', "minValue": 2500, "timetoSend":"5"},
-                            {"name":'/help/faq', "minValue": 500, "timetoSend":"3"}];
+          var routeNames = [{"name":'/', "minValue": 1000, "timetoSend":"4"},
+                       //     {"name":'/home', "minValue": 1500, "timetoSend":"2"},
+                       //     {"name":'/shop', "minValue": 3000, "timetoSend":"1"},
+                       //     {"name":'/shop/chart/', "minValue": 2000, "timetoSend":"3"},
+                       //     {"name":'/help', "minValue": 2500, "timetoSend":"2"},
+                       //     {"name":'/help/faq', "minValue": 500, "timetoSend":"3"}
+                       ];
 
            // Send ALT for rounte
             
@@ -45,6 +46,7 @@
                 for (var i =0; i < k; i++) {
                 appInsights.core._extensions[2].operation.id = newId();
                 mezzurite.EventElement.dispatchEvent(new CustomEvent('Timing', {detail:CreateTimingObject(e.name, 2 * e.minValue , increase, true)}));
+                appInsights.core._extensions[2].operation.id = newId();
                 mezzurite.EventElement.dispatchEvent(new CustomEvent('Timing', {detail:CreateTimingObject(e.name, e.minValue , increase, false)}));
                 }
                 
@@ -76,8 +78,8 @@
             var vlt = 0;
 
             vltC.forEach((e)=> {
-                if (vlt < e.componentLoadTime){
-                vlt = e.componentLoadTime;
+                if (vlt < e.clt){
+                vlt = e.clt;
                 }
             });
 


### PR DESCRIPTION
Fixing the open issue.  Now logging ALT, VLT, FVLT under measurements via their full names.  Also fixed some issues with the test page.  

I removed logging of start/endtimes for components as they are not needed in the current views of the data in app insights.  

Moved Redirect from a measurement to a prop on each of the metric types. #13 